### PR TITLE
Add random question endpoint

### DIFF
--- a/server/controller/index.js
+++ b/server/controller/index.js
@@ -26,6 +26,14 @@ exports.getQuestions = async (ctx) => {
     });
 };
 
+exports.getRandomQuestions = async (ctx) => {
+  await Question.getRandom(ctx.params.limit)
+    .then((result) => {
+      ctx.body = result;
+      return ctx.body;
+    });
+};
+
 exports.getId = async (ctx) => {
   await Question.findById(ctx.params.id)
     .then((result) => {

--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,7 @@ router
     ctx.body = 'Hello Koa';
   })
   .get('/api/questions', QuestionController.getQuestions)
+  .get('/api/questions/random/:limit?', QuestionController.getRandomQuestions)
   .get('/api/question/:id', QuestionController.getId);
 
 app

--- a/server/models/question.js
+++ b/server/models/question.js
@@ -15,6 +15,12 @@ const questionSchema = mongoose.Schema(
   },
 );
 
+questionSchema.statics.getRandom = function getRandom(limit = 1) {
+  return this.aggregate([{
+    $sample: { size: +limit },
+  }]);
+};
+
 const questionModel = mongoose.model('Question', questionSchema);
 
 module.exports = questionModel;


### PR DESCRIPTION
I've just added a new endpoint where we can retrieve random questions. It uses MongoDB's aggregate framework to get a number of random questions. The default limit is 1 so `/api/questions/random` returns an array with one single question. 

You can get more than one random questions by adding a number as a parameter like `/api/questions/random/10`.

Closes #30 