### PR TITLE
Fix VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
   "editor.wordWrapColumn": 100,
   "files.encoding": "utf8",
   "files.eol": "\n",
-  "files.insertFinalNewline": false,
+  "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true
 }


### PR DESCRIPTION
It fixes the final newline insertion in VS Code. Lame, but I tried checking if this file overrides my user settings right before my previous PR and committed the `"files.insertFinalNewline": false` line which doesn't insert new lines. Sorry about that :(
