### PR TITLE
Fix FormatDate tests

### DIFF
--- a/client/tests/components/FormatDate.test.jsx
+++ b/client/tests/components/FormatDate.test.jsx
@@ -1,12 +1,69 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
-
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import FormatDate from 'Components/FormatDate';
 
-describe('FormatDate', () => {
-  it('should match the snapshot', () => {
-    const date = renderer.create(<FormatDate date="2017-12-14T22:43:56.069Z" />);
+Enzyme.configure({ adapter: new Adapter() });
 
-    expect(date.toJSON()).toMatchSnapshot();
+const defaultFormat = {
+  year: undefined,
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: undefined,
+};
+const defaultLocales = 'en-GB';
+
+describe('FormatDate', () => {
+  it('should render a time element with dateTime attribute', () => {
+    const formatDate = shallow(<FormatDate />);
+    const time = formatDate.find('time');
+
+    expect(time.length).toBe(1);
+    expect(time.props().dateTime).toBeDefined();
+  });
+
+  it('should render a time element with the current date and time by default', () => {
+    const formatDate = shallow(<FormatDate />);
+    const time = formatDate.find('time');
+    const expectedTime = new Date().toLocaleString(defaultLocales, defaultFormat);
+
+    expect(time.props().dateTime).toBeDefined();
+    expect(time.text()).toBe(expectedTime);
+  });
+
+  it('should render the correct time element if date prop is provided', () => {
+    const date = '2017-12-14T22:43:56.069Z';
+    const formatDate = shallow(<FormatDate date={date} />);
+    const time = formatDate.find('time');
+    const expectedTime = new Date(date).toLocaleString(defaultLocales, defaultFormat);
+
+    expect(time.props().dateTime).toBe(date);
+    expect(time.text()).toBe(expectedTime);
+  });
+
+  it('should render the correct time element if locale and format props are provided', () => {
+    const format = {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    };
+    const locales = 'hu';
+    const date = '2017-12-14T22:43:56.069Z';
+    const formatDate = shallow(<FormatDate
+      date={date}
+      format={format}
+      locales={locales}
+    />);
+    const time = formatDate.find('time');
+    const expectedTime = new Date(date).toLocaleString(locales, format);
+
+    expect(time.props().dateTime).toBe(date);
+    expect(time.text()).toBe(expectedTime);
   });
 });

--- a/client/tests/components/__snapshots__/FormatDate.test.jsx.snap
+++ b/client/tests/components/__snapshots__/FormatDate.test.jsx.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`FormatDate should match the snapshot 1`] = `
-<time
-  dateTime="2017-12-14T22:43:56.069Z"
->
-  Dec 14, 10:43 PM
-</time>
-`;


### PR DESCRIPTION
As @OStefani mentioned earlier, if you're in a different timezone, the current tests of the `FormatDate` component fail. As @Heyjp is in the same timezone as me, he couldn't notice this issue when he reviewed my PR.